### PR TITLE
headerの幅調整

### DIFF
--- a/components/HeaderOutline.vue
+++ b/components/HeaderOutline.vue
@@ -1,6 +1,6 @@
 <template>
   <nav class="navbar navbar-light glass sticky-top">
-    <div class="container-fluid">
+    <div class="container-fluid max-width">
       <a class="navbar-brand" href=""></a>
       <div class="">
         <slot />


### PR DESCRIPTION
Headerの横幅をFooterと同じになるように修正しました。
よろしくおねがいします。

https://cdn.discordapp.com/attachments/1076030840460550245/1085827214857220156/Screenshot_from_2023-03-16_16-29-07.png